### PR TITLE
Updated to use seneca@0.5.17, tests passing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Richard Rodger (http://richardrodger.com)",
   "license": "MIT",
   "devDependencies": {
-    "seneca": "0.5.15",
+    "seneca": "0.5.17",
     "connect": "2.12.x",
     "mocha": "1.17.x",
     "gex": "0.1.x",

--- a/test/perm.test.js
+++ b/test/perm.test.js
@@ -73,8 +73,8 @@ describe('perm', function() {
         assert.equal('123',out)
       })
 
-      si.act('a:1,c:3',{perm$:{act:act}},function(err,out){
-        assert.isNotNull(err)
+      assert.throws(function() {
+        si.act('a:1,c:3',{perm$:{act:act}});
       })
 
     })
@@ -121,8 +121,8 @@ describe('perm', function() {
         pf1.a=2
       ;pf1.save$(function(err,pf1){
         assert.isNotNull(err)
-        assert.equal('cr',err.seneca.allowed)
-        assert.equal('u',err.seneca.need)
+        assert.equal('cr',err.seneca.valmap.allowed)
+        assert.equal('u',err.seneca.valmap.need)
 
 
       ;pb1.list$({b:2},function(err,list){
@@ -166,8 +166,8 @@ describe('perm', function() {
 
       ;pf1.list$({a:1},function(err,list){
         assert.isNotNull(err)
-        assert.equal(null,err.seneca.allowed)
-        assert.equal('q',err.seneca.need)
+        assert.equal(null,err.seneca.valmap.allowed)
+        assert.equal('q',err.seneca.valmap.need)
 
 
       ;pb1.list$({b:2},function(err,list){
@@ -217,7 +217,7 @@ describe('perm', function() {
           f2.load$(f1.id,function(err,f2o){
             assert.isNotNull(err)
             assert.equal('perm/fail/own',err.seneca.code)
-            assert.equal('o2',err.seneca.owner)
+            assert.equal('o2',err.seneca.valmap.owner)
             //console.log(err)
           })
         })


### PR DESCRIPTION
Ref #5.
- Updated instances of deprecated `seneca.fail(…, callback)`

Updated tests:
- seneca throws on non-mapped action pattern as of rjrodger/seneca@237b343d8985d88a8e27fc8b1ff3a2dee9d67d36 (`instance.fail` was called prior to this)
- err.valmap added in rjrodger/seneca@cd8024f40444c0d6b6396d351d34f5d2439c5c1b
