### PR TITLE
acl filters are applied based on user input not saved object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"

--- a/lib/ACLMicroservicesBuilder.js
+++ b/lib/ACLMicroservicesBuilder.js
@@ -34,7 +34,6 @@ function ACLMicroservicesBuilder(seneca) {
   }
 
   this._executeSavePermissionsWrapper = function(args, callback) {
-
     if(args.perm$) {
 
       this.ACLMicroservicesBuilder = self;
@@ -158,8 +157,6 @@ ACLMicroservicesBuilder.prototype._executeReadPermissions = function(args, callb
     if(err || !entity) {
       callback(err, undefined)
     } else {
-      // console.log('ENTITY', entity)
-      // console.log('CONTEXT', context)
       self._deepAuthorize(entityDef, entity, args.cmd, args.cmd, roles, context, true, args.showSoftDenied$, function(err, entity) {
         callback(err, entity)
       })
@@ -229,42 +226,39 @@ ACLMicroservicesBuilder.prototype._executeSavePermissions = function(args, callb
 
   if(args.ent.id) { // update
 
-    self.ACLMicroservicesBuilder._loadAndAuthorize(entityDef, args.ent.id, args.cmd, roles, context, args.showSoftDenied$, function(err, dbEntity) {
+    self.ACLMicroservicesBuilder._loadAndAuthorize(entityDef, args.ent.id, args.cmd, roles, context, args.showSoftDenied$,args.ent, function(err, dbEntity) {
 
       if(err) {
 
-        callback(err, undefined)
+        return callback(err, undefined)
 
-      } else {
+      }
 
-        // also execute permission checks on the new attributes
-        self.ACLMicroservicesBuilder._deepAuthorize(entityDef, args.ent, args.cmd, 'save_new', roles, context, true, args.showSoftDenied$, function(err, filteredEntity) {
+      // also execute permission checks on the new attributes
+      self.ACLMicroservicesBuilder._deepAuthorize(entityDef, args.ent, args.cmd, 'save_existing', roles, context, true, args.showSoftDenied$, function(err, filteredEntity) {
 
+        if(err) {
+
+          return callback(err, undefined)
+
+        }
+
+        merge(dbEntity, args.ent)
+        delete args.perm$
+
+        self.prior(args, function(err, entity) {
           if(err) {
-
-            callback(err, undefined)
-
-          } else {
-
-            merge(dbEntity, args.ent)
-
-            delete args.perm$
-
-            self.prior(args, function(err, entity) {
-              if(err) {
-                return callback(err, undefined)
-              }
-
-              // the entity returned by the save needs to be filtered again
-              self.ACLMicroservicesBuilder._filter(entityDef, entity, 'load', roles, context, function(err, entity) {
-                callback(err, entity)
-              })
-
-            })
+            return callback(err, undefined)
           }
 
+          // the entity returned by the save needs to be filtered again
+          self.ACLMicroservicesBuilder._filter(entityDef, entity, 'load', roles, context, function(err, entity) {
+            callback(err, entity)
+          })
+
         })
-      }
+        //
+      })
     })
 
   } else { // create
@@ -293,9 +287,16 @@ ACLMicroservicesBuilder.prototype._executeSavePermissions = function(args, callb
 
 }
 
-ACLMicroservicesBuilder.prototype._loadAndAuthorize = function(entityDef, entityId, action, roles, context, showSoftDenied, callback) {
+ACLMicroservicesBuilder.prototype._loadAndAuthorize = function(entityDef, entityId, action, roles, context, showSoftDenied,filterEntity, callback) {
 
   var self = this
+
+  // the filterEntity is an optional arg.
+  // when provided ACL filters that appply to the dbEntity are applied on this entity instead.
+  if(typeof filterEntity === "function"){
+    callback = filterEntity;
+    filterEntity = false;
+  }
 
   var ent = this._seneca.make(canonize(entityDef))
 
@@ -310,7 +311,7 @@ ACLMicroservicesBuilder.prototype._loadAndAuthorize = function(entityDef, entity
       ruleAction = action
     }
 
-    self._deepAuthorize(entityDef, dbEntity, action, ruleAction, roles, context, false, showSoftDenied, function(err, entity) {
+    self._deepAuthorize(entityDef, dbEntity, action, ruleAction, roles, context, filterEntity, showSoftDenied, function(err, entity) {
       callback(err, err ? undefined : dbEntity)
     })
   })
@@ -334,8 +335,21 @@ ACLMicroservicesBuilder.prototype._filter = function(entityDef, entity, action, 
   }
 }
 
+
+
 ACLMicroservicesBuilder.prototype._deepAuthorize = function(entityDef, entity, action, ruleAction, roles, context, applyFilters, showSoftDenied, callback) {
   var self = this
+
+  // NOTE:
+  // a silly dance to grab the object that i should filter.
+  // on save_existing the applicable filters must be loaded from the context of the saved entity
+  // but applied to the data changes in the new object.
+  //
+  var filterEntity = entity;
+  if(applyFilters && typeof applyFilters.save$ === 'function'){
+    filterEntity = applyFilters;
+    applyFilters = true;
+  }
 
   var aclProcedure = AccessControlProcedure.getProcedureForEntity(self._ACLProcedureResolver, entityDef, action)
 
@@ -354,12 +368,11 @@ ACLMicroservicesBuilder.prototype._deepAuthorize = function(entityDef, entity, a
       if(err) {
         callback(err, undefined)
       } else {
-        //console.log(JSON.stringify(authDecision, null, 2))
         debug('_deepAuthorize decision', JSON.stringify(authDecision))
         var inheritDetails = inherit(authDecision)
 
         if(applyFilters) {
-          aclProcedure.applyFilters(authDecision.filters, entity, action)
+          aclProcedure.applyFilters(authDecision.filters, filterEntity, action)
         }
         
         if(inheritDetails) {

--- a/lib/ACLMicroservicesBuilder.js
+++ b/lib/ACLMicroservicesBuilder.js
@@ -235,7 +235,7 @@ ACLMicroservicesBuilder.prototype._executeSavePermissions = function(args, callb
       }
 
       // also execute permission checks on the new attributes
-      self.ACLMicroservicesBuilder._deepAuthorize(entityDef, args.ent, args.cmd, 'save_existing', roles, context, true, args.showSoftDenied$, function(err, filteredEntity) {
+      self.ACLMicroservicesBuilder._deepAuthorize(entityDef, args.ent, args.cmd, 'save_new', roles, context, true, args.showSoftDenied$, function(err, filteredEntity) {
 
         if(err) {
 

--- a/lib/ACLMicroservicesBuilder.js
+++ b/lib/ACLMicroservicesBuilder.js
@@ -2,7 +2,7 @@
 var _ = require('lodash')
 var AccessControlProcedure = require('access-controls')
 
-var DEBUG = false
+var DEBUG = process.env.ACL_DEBUG||false
 
 var ACL_ERROR_CODE = 'perm/fail/acl'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-perm",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Seneca permissions plugin",
   "main": "perm.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-perm",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Seneca permissions plugin",
   "main": "perm.js",
   "scripts": {

--- a/test/perm.acl.filter-saveexisting.test.js
+++ b/test/perm.acl.filter-saveexisting.test.js
@@ -1,0 +1,125 @@
+/* Copyright (c) 2013-2014 Richard Rodger */
+"use strict";
+
+
+// mocha perm.test.js
+
+
+var seneca  = require('seneca')
+
+var assert  = require('chai').assert
+
+
+
+describe('perm acl', function() {
+
+  var si = seneca()
+
+  si.use( require('../perm.js'), {
+    accessControls: [
+      {
+        name: 'cannot save changes to happy attribute if it\'s already happy',
+        roles: ['foobar', 'happy'],
+        entities: [{
+          zone: undefined,
+          base: undefined,
+          name: 'foobar'
+        }],
+        control: 'filter',
+        actions: ['save_new', 'save_existing'],
+        conditions: [{
+          attributes:{
+            happy:1
+          }
+        }],
+        filters: {
+          happy: false
+        }
+      },
+      {
+        name: 'access to foobars',
+        roles: ['foobar'],
+        entities: [{
+          zone: undefined,
+          base: undefined,
+          name: 'foobar'
+        }],
+        control: 'required',
+        actions: ['save_new', 'save_existing','list', 'load', 'remove'],
+        conditions: [],
+      }
+    ],
+    allowedProperties: [{
+      entity: {
+        zone: undefined,
+        base: undefined,
+        name: 'foobar'
+      },
+      fields: ['id','name', 'number','happy','tacos']
+    }]
+  })
+
+  it('seneca ready', function(done) {
+    this.timeout(10000)
+    si.ready(done)
+  })
+
+  // worked before this test.
+  it('[save_new] filters should apply to conditional property.', function(done){
+    var psiNoHappy = si.delegate({perm$:{roles:['foobar']}})
+
+    var e = psiNoHappy.make('foobar',{a:'a',happy:1})
+    
+    e.save$(function(err,e){
+      assert.isNull(err, err)
+      assert.isNotNull(e, 'missing entity')
+      assert.equal(e.happy, undefined,'should not have saved change to happy property') 
+
+      done();
+    })
+  })
+  
+  it('[save_existing] filters should apply to conditional property.', function(done) {
+
+    var psi = si.delegate({perm$:{roles:['foobar', 'happy']}})
+    var psiNoHappy = si.delegate({perm$:{roles:['foobar']}})
+
+    var pf1 = psi.make('foobar',{a:'a',happy:1})
+    var pf1NoHappy = psiNoHappy.make('foobar',{b:'b',happy:1})
+
+    ;pf1.save$(function(err, pf1){
+      assert.isNull(err, err)
+      console.log('saved ',pf1);
+
+      assert.isNotNull(pf1.id, 'missing pf1.id')
+      assert.equal(pf1.happy, 1)
+
+    ;pf1NoHappy.load$(pf1.id,function(err, pf1NoHappy) {
+      assert.isNull(err, err)
+      assert.isNotNull(pf1NoHappy, 'missing entity')
+      assert.equal(pf1NoHappy.happy, 1,'should not have saved change to happy property') 
+
+      console.log('loaded happy entity',pf1NoHappy);
+
+      pf1NoHappy.tacos = "yum"
+      pf1NoHappy.happy = 0
+      console.log("====================================++>>>>>>")
+      console.log('attempting to make happy entity unhappy',pf1NoHappy);
+    ;pf1NoHappy.save$(function(err, pf1NoHappy) {
+
+      if(!pf1NoHappy.happy) console.log('happy entity shouldnt be unhappy!',pf1NoHappy);
+      else console.log('yay still happy!');
+
+      assert.isNull(err, err)
+      assert.isNotNull(pf1NoHappy, 'missing entity')
+      assert.equal(pf1NoHappy.happy, 1,'should not have saved change to happy property') 
+      assert.equal(pf1NoHappy.tacos, "yum",'should have saved new tacos property')
+
+
+      done()
+
+    }) }) })
+
+  })
+
+})


### PR DESCRIPTION
where acl filters change based on an object property
the acl was applied in the context of the users changes rather than the
saved object. This bug allowed users to ignore filter settings on updates.

