### PR TITLE
Fixing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
+  - "6"

--- a/README.md
+++ b/README.md
@@ -139,12 +139,16 @@ app.listen(3000)
 The perm plugin does not wrap other actions immediately when it is registered. Rather, you call the _role:perm, cmd:init_ action
 when you're ready. First you need to add any other plugins and actions that you want to apply permissions checking to.
 
+### Seneca Compatibility
 
+Supports Seneca versions 1.x - 3.x
 
 ## Install
 
 ```sh
 npm install seneca
+npm install seneca-basic
+npm install seneca-entity
 npm install seneca-perm
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "mocha": "1.17.x",
     "gex": "0.1.x",
     "async": "0.2.x",
-    "chai": "1.8.x"
+    "chai": "1.8.x",
+    "seneca-basic": "^0.5.0",
+    "seneca-echo": "^0.3.0",
+    "seneca-entity": "^1.3.0"
   },
   "dependencies": {
     "access-controls": "~0.5.2",

--- a/test/perm.acl.filter-saveexisting.test.js
+++ b/test/perm.acl.filter-saveexisting.test.js
@@ -15,6 +15,10 @@ describe('perm acl', function() {
 
   var si = seneca()
 
+  si.use('seneca-entity')
+
+  si.use('seneca-basic')
+
   si.use( require('../perm.js'), {
     accessControls: [
       {

--- a/test/perm.acl.filters.test.js
+++ b/test/perm.acl.filters.test.js
@@ -17,6 +17,10 @@ describe('perm acl', function() {
 
   var si = seneca()
 
+  si.use('seneca-entity')
+
+  si.use('seneca-basic')
+
   si.use( require('../perm.js'), {
     accessControls: [{
       name: 'access to region attribute',

--- a/test/perm.acl.properties.test.js
+++ b/test/perm.acl.properties.test.js
@@ -17,6 +17,10 @@ describe('perm acl', function() {
 
   var si = seneca()
 
+  si.use('seneca-entity')
+
+  si.use('seneca-basic')
+
   si.use( '../perm.js', {
     accessControls: [{
       name: 'hard set to true',

--- a/test/perm.acl.remove.test.js
+++ b/test/perm.acl.remove.test.js
@@ -17,6 +17,10 @@ describe('perm acl', function() {
 
   var si = seneca()
 
+  si.use('seneca-entity')
+
+  si.use('seneca-basic')
+
   si.use( '../perm.js', {
     accessControls: [{
       name: 'can delete foobar',
@@ -63,8 +67,7 @@ describe('perm acl', function() {
 
     ;pf1.remove$({ id: pf1.id }, function(err, pf1){
       assert.isNull(err, err)
-      assert.isNotNull(pf1.id, 'missing pf1.id')
-      assert.equal(pf1.region, 'EMEA')
+      assert.isNull(pf1, pf1)
       done()
 
     }) }) })

--- a/test/perm.acl.test.js
+++ b/test/perm.acl.test.js
@@ -17,6 +17,10 @@ describe('perm acl', function() {
 
   var si = seneca()
 
+  si.use('seneca-entity')
+
+  si.use('seneca-basic')
+
   si.use( '..', {
     accessControls: [
       {
@@ -187,7 +191,7 @@ describe('perm acl', function() {
 
     ;pf1.save$(function(err, empty) {
       assert.ok(err, 'expected a permission denied error but did not get any')
-      assert.equal(err.code, 'perm/fail/acl', 'expected error code to be ACL related')
+      assert.equal(err.orig.code, 'perm/fail/acl', 'expected error code to be ACL related')
 
       done()
     }) }) }) })
@@ -228,7 +232,7 @@ describe('perm acl', function() {
 
     ;pf1.save$(function(err, pf1) {
       assert.ok(err, 'expected a permission denied error but did not get any')
-      assert.equal(err.code, 'perm/fail/acl', 'expected error code to be ACL related')
+      assert.equal(err.orig.code, 'perm/fail/acl', 'expected error code to be ACL related')
 
       done()
     })
@@ -244,7 +248,7 @@ describe('perm acl', function() {
 
     ;pf1.save$(function(err,pf1){
       assert.isNotNull(err, 'expected ACL error but did not get any')
-      assert.equal(err.code, 'perm/fail/acl')
+      assert.equal(err.orig.code, 'perm/fail/acl')
 
       done()
     })
@@ -338,13 +342,13 @@ describe('perm acl', function() {
 
     ;pf11.save$(function(err, pf11) {
       assert.isNotNull(err, 'user should be denied update capability because he can only update EMEA entities')
-      assert.equal(err.code, 'perm/fail/acl', 'expected error code to be ACL related')
+      assert.equal(err.orig.code, 'perm/fail/acl', 'expected error code to be ACL related')
 
       var pf12 = foobar2Seneca.make('foobar',{id: pf1.id, region: 'APAC'})
 
     ;pf12.save$(function(err, pf12) {
       assert.isNotNull(err, 'user should be denied update capability')
-      assert.equal(err.code, 'perm/fail/acl', 'expected error code to be ACL related')
+      assert.equal(err.orig.code, 'perm/fail/acl', 'expected error code to be ACL related')
 
       done()
     }) }) })
@@ -376,7 +380,7 @@ describe('perm acl', function() {
 
     ;deniedItem.load$(item.id, function(err,deniedItem){
       assert.isNotNull(err, 'expected read access to be denied by inheritance')
-      assert.equal(err.code, 'perm/fail/acl')
+      assert.equal(err.orig.code, 'perm/fail/acl')
 
       done()
     }) }) }) })
@@ -405,7 +409,7 @@ describe('perm acl', function() {
 
     ;deniedItem.save$(function(err, deniedItem){
       assert.isNotNull(err, 'expected create capability to be denied')
-      assert.equal(err.code, 'perm/fail/acl')
+      assert.equal(err.orig.code, 'perm/fail/acl')
 
       done()
     }) }) })
@@ -439,7 +443,7 @@ describe('perm acl', function() {
 
     ;deniedItem.save$(function(err, deniedItem){
       assert.isNotNull(err, 'expected update capability to be denied due to inheritance')
-      assert.equal(err.code, 'perm/fail/acl')
+      assert.equal(err.orig.code, 'perm/fail/acl')
 
       done()
     }) }) }) })

--- a/test/perm.app.js
+++ b/test/perm.app.js
@@ -35,8 +35,8 @@ seneca.use('..',{
 seneca.ready(function(){
 
   var b1, b2
-  seneca.make$('bar',{a:1,owner:'o1'}).save$(function(e,o){b1=o})
-  seneca.make$('bar',{a:2,owner:'o2'}).save$(function(e,o){b2=o})
+  seneca.make('bar',{a:1,owner:'o1'}).save$(function(e,o){b1=o})
+  seneca.make('bar',{a:2,owner:'o2'}).save$(function(e,o){b2=o})
 
   var barmap = {
     b1:b1,

--- a/test/perm.test.js
+++ b/test/perm.test.js
@@ -19,7 +19,11 @@ describe('perm', function() {
   it('allow', function(fin){
     var si = seneca()
 
-    si.add({a:1,b:2},function(args,done){done(null,''+args.a+args.b+args.c)})
+    si.use('seneca-entity')
+
+    si.use('seneca-basic')
+
+    si.add({a:1,b:2},function(args,done){done(null,{msg: ''+args.a+args.b+args.c})})
 
 
     si.use( '..', {act:[
@@ -32,11 +36,11 @@ describe('perm', function() {
 
       ;si.act('a:1,b:2,c:3',function(err,out){
         assert.ok( null == err )
-        assert.equal('123',out)
+        assert.equal('123',out.msg)
 
       ;si.act('a:1,b:2,c:3',{perm$:{allow:true}},function(err,out){
         assert.ok( null == err )
-        assert.equal('123',out)
+        assert.equal('123',out.msg)
 
       ;si.act('a:1,b:2,c:3',{perm$:{allow:false}},function(err,out){
         assert.isNotNull(err)
@@ -44,11 +48,11 @@ describe('perm', function() {
 
       ;si.act('a:1,b:2,c:3,d:4',function(err,out){
         assert.ok( null == err )
-        assert.equal('123',out)
+        assert.equal('123',out.msg)
 
       ;si.act('a:1,b:2,c:3,d:4',{perm$:{allow:true}},function(err,out){
         assert.ok( null == err )
-        assert.equal('123',out)
+        assert.equal('123',out.msg)
 
       ;si.act('a:1,b:2,c:3,d:4',{perm$:{allow:false}},function(err,out){
         assert.isNotNull(err)
@@ -59,7 +63,7 @@ describe('perm', function() {
 
       ;si.act('a:1,b:2,c:3',{perm$:{act:act}},function(err,out){
         assert.ok( null == err )
-        assert.equal('123',out)
+        assert.equal('123',out.msg)
 
         fin();
 
@@ -72,13 +76,16 @@ describe('perm', function() {
   it('entity', function(fin){
     var si = seneca()
 
+    si.use('seneca-entity')
+
+    si.use('seneca-basic')
+
     si.use( '..', {
       entity:[
         {name:'foo'},
         'bar'
       ]
     })
-
 
     si.ready(function(){
 
@@ -130,6 +137,10 @@ describe('perm', function() {
   it('entity-boolean', function(fin){
     var si = seneca()
 
+    si.use('seneca-entity')
+
+    si.use('seneca-basic')
+
     si.use( '..', {
       // apply perm check to all entities
       entity:true
@@ -170,6 +181,10 @@ describe('perm', function() {
 
   it('owner', function(fin){
     var si = seneca()
+
+    si.use('seneca-entity')
+
+    si.use('seneca-basic')
 
     si.use( '..', {
       own:[
@@ -217,6 +232,10 @@ describe('perm', function() {
   it('makeperm',function(fin){
     var si = seneca()
 
+    si.use('seneca-entity')
+
+    si.use('seneca-basic')
+
     si.use( '..', {
       act:[
         {a:1},
@@ -225,8 +244,8 @@ describe('perm', function() {
     })
 
 
-    si.add({a:1},function(args,done){done(null,''+args.a+args.c)})
-    si.add({b:2},function(args,done){done(null,''+args.b+args.c)})
+    si.add({a:1},function(args,done){done(null,{msg:''+args.a+args.c})})
+    si.add({b:2},function(args,done){done(null,{msg:''+args.b+args.c})})
 
 
     si.ready(function(){
@@ -238,11 +257,11 @@ describe('perm', function() {
 
         si.act('a:1,c:3',{perm$:perm},function(err,out){
           assert.ok( null == err )
-          assert.equal('13',out)
+          assert.equal('13',out.msg)
           
           si.act('b:2,c:3',{perm$:perm},function(err,out){
             assert.isNotNull(err)
-            assert.equal('perm/fail/act',err.seneca.code)
+            assert.equal('perm/fail/act',err.code)
 
             fin()
           })


### PR DESCRIPTION
Summary of changes:
- added seneca-entity and seneca-basic to all instantiations of seneca
- error codes weren't looking in the right spot
- actions were responding with strings (needs to be object/array)
- a few instances of `seneca.make$` instead of `seneca.make`
- updated README to clarify seneca-entity and seneca-basic requirement

Fixes #4
